### PR TITLE
Set abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Adding a command is as simple as creating a new package to hold your commands. T
 
 An example command is provided to develop new commands, but additional examples are needed to demostrate sharing state between commands as well as a feature list for better sharing techniques between the POST and GET commands.
 
+Alternatively, you can create your own main function that uses the RunShell() function to run all the initialization for you and maintain a separate package/repository with your commands and any dependent commands. Your main package would be able to include any package desired.
+
 ## Assertions (Assert)
 All REST commands store responses in a history buffer such that assertions can be run against the history buffer. Assertions are designed to use a simplistic XPATH-like mechanism to identify and extract a property value in a JSON response to perform validations against.
 

--- a/commands/about/about.go
+++ b/commands/about/about.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 type AboutCommand struct {
@@ -28,7 +27,7 @@ func NewAboutCommand() *AboutCommand {
 	return &AboutCommand{}
 }
 
-func (cmd *AboutCommand) AddOptions(set *getopt.Set) {
+func (cmd *AboutCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("topic")
 	shell.AddCommonCmdOptions(set, shell.CmdDebug, shell.CmdVerbose)
 }

--- a/commands/about/version.go
+++ b/commands/about/version.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 var BuildCommit string
@@ -38,7 +37,7 @@ func NewVersionCommand() *VersionCommand {
 	}
 }
 
-func (cmd *VersionCommand) AddOptions(set *getopt.Set) {
+func (cmd *VersionCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("")
 	shell.AddCommonCmdOptions(set, shell.CmdDebug, shell.CmdVerbose)
 }

--- a/commands/example/benchmark.go
+++ b/commands/example/benchmark.go
@@ -5,7 +5,6 @@ import (
 	"strconv"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 type BmCommand struct {
@@ -16,7 +15,7 @@ func NewBmCommand() *BmCommand {
 	return &BmCommand{}
 }
 
-func (cmd *BmCommand) AddOptions(set *getopt.Set) {
+func (cmd *BmCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("value")
 	shell.AddCommonCmdOptions(set, shell.CmdDebug, shell.CmdVerbose, shell.CmdBenchmarks)
 }

--- a/commands/example/example.go
+++ b/commands/example/example.go
@@ -2,7 +2,6 @@ package example
 
 import (
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 type ExampleCommand struct {
@@ -13,7 +12,7 @@ func NewExampleCommand() *ExampleCommand {
 	return &ExampleCommand{}
 }
 
-func (cmd *ExampleCommand) AddOptions(set *getopt.Set) {
+func (cmd *ExampleCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("value")
 	shell.AddCommonCmdOptions(set, shell.CmdDebug, shell.CmdVerbose)
 }

--- a/commands/example/exquery.go
+++ b/commands/example/exquery.go
@@ -6,7 +6,6 @@ import (
 	"io"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 var (
@@ -21,7 +20,7 @@ func NewExqueryCommand() *ExqueryCommand {
 	return &ExqueryCommand{}
 }
 
-func (cmd *ExqueryCommand) AddOptions(set *getopt.Set) {
+func (cmd *ExqueryCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("value")
 
 	// Add command helpers for verbose, debug, restclient and output formatting

--- a/commands/kubectl/kubectl.go
+++ b/commands/kubectl/kubectl.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 var ()
@@ -22,7 +21,7 @@ func NewKubectlCommand() *KubectlCommand {
 	return &KubectlCommand{}
 }
 
-func (cmd *KubectlCommand) AddOptions(set *getopt.Set) {
+func (cmd *KubectlCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("kubectl_command [options]")
 	set.SetUsage(func() {
 		set.PrintUsage(shell.ConsoleWriter())

--- a/commands/rest/base.go
+++ b/commands/rest/base.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 var (
@@ -23,7 +22,7 @@ func NewBaseCommand() *BaseCommand {
 	return &BaseCommand{}
 }
 
-func (cmd *BaseCommand) AddOptions(set *getopt.Set) {
+func (cmd *BaseCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("[baseurl]")
 	cmd.clearOption = set.BoolLong("clear", 'c', "Clear the base URL")
 	shell.AddCommonCmdOptions(set, shell.CmdDebug, shell.CmdVerbose, shell.CmdUrl, shell.CmdBasicAuth, shell.CmdQueryParamAuth)

--- a/commands/rest/bmget.go
+++ b/commands/rest/bmget.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 type BmGetCommand struct {
@@ -19,7 +18,7 @@ func NewBmGetCommand() *BmGetCommand {
 	return &BmGetCommand{}
 }
 
-func (cmd *BmGetCommand) AddOptions(set *getopt.Set) {
+func (cmd *BmGetCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("[service route]")
 	cmd.optionUseHead = set.BoolLong("head", 0, "Use HTTP HEAD method")
 	cmd.optionUseDelete = set.BoolLong("delete", 0, "Use HTTP DELETE method")

--- a/commands/rest/get.go
+++ b/commands/rest/get.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 type GetCommand struct {
@@ -17,7 +16,7 @@ func NewGetCommand() *GetCommand {
 	return &GetCommand{}
 }
 
-func (cmd *GetCommand) AddOptions(set *getopt.Set) {
+func (cmd *GetCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("[service route]")
 	cmd.optionUseHead = set.BoolLong("head", 0, "Use HTTP HEAD method")
 	cmd.optionUseDelete = set.BoolLong("delete", 0, "Use HTTP DELETE method")

--- a/commands/rest/post.go
+++ b/commands/rest/post.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
+// Default values for options
 const (
 	DefaultJsonVar  = ""
 	DefaultJsonBody = ""
@@ -32,7 +32,7 @@ func NewPostCommand() *PostCommand {
 	return &PostCommand{}
 }
 
-func (cmd *PostCommand) AddOptions(set *getopt.Set) {
+func (cmd *PostCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("[service route]")
 	cmd.optionUsePut = set.BoolLong("put", 0, "Use PUT method instead of post")
 	cmd.optionUseOption = set.BoolLong("options", 0, "Use OPTIONS method instead of post")

--- a/commands/util/alias.go
+++ b/commands/util/alias.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 type AliasCommand struct {
@@ -16,7 +15,7 @@ func NewAliasCommand() *AliasCommand {
 	return &AliasCommand{}
 }
 
-func (cmd *AliasCommand) AddOptions(set *getopt.Set) {
+func (cmd *AliasCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("[[alias] command]")
 	shell.AddCommonCmdOptions(set, shell.CmdDebug, shell.CmdVerbose)
 }

--- a/commands/util/assert.go
+++ b/commands/util/assert.go
@@ -11,8 +11,6 @@ import (
 	"strings"
 
 	"github.com/brada954/restshell/shell"
-
-	"github.com/pborman/getopt/v2"
 )
 
 type AssertCommand struct {
@@ -52,7 +50,7 @@ func (cmd *AssertCommand) GetSubCommands() []string {
 
 type ValueModifier func(i interface{}) (interface{}, error)
 
-func (cmd *AssertCommand) AddOptions(set *getopt.Set) {
+func (cmd *AssertCommand) AddOptions(set shell.CmdSet) {
 	set.SetProgram("assert [sub command]")
 	set.SetUsage(func() {
 		cmd.HeaderUsage(shell.ConsoleWriter())

--- a/commands/util/cd.go
+++ b/commands/util/cd.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 type CdCommand struct {
@@ -28,7 +27,7 @@ func NewCdCommand() *CdCommand {
 	return cmd
 }
 
-func (cmd *CdCommand) AddOptions(set *getopt.Set) {
+func (cmd *CdCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("value")
 	cmd.resetDir = set.BoolLong("reset", 'r', "Reset current working directory to initial startup")
 }

--- a/commands/util/debug.go
+++ b/commands/util/debug.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 type DebugCommand struct {
@@ -17,7 +16,7 @@ func NewDebugCommand() *DebugCommand {
 	return &DebugCommand{}
 }
 
-func (cmd *DebugCommand) AddOptions(set *getopt.Set) {
+func (cmd *DebugCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("value")
 	shell.AddCommonCmdOptions(set, shell.CmdDebug, shell.CmdVerbose)
 }

--- a/commands/util/diff.go
+++ b/commands/util/diff.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 var ()
@@ -22,7 +21,7 @@ func NewDiffCommand() *DiffCommand {
 	return &DiffCommand{}
 }
 
-func (cmd *DiffCommand) AddOptions(set *getopt.Set) {
+func (cmd *DiffCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("[-- {git options for git diff --no-index}] file1 file2")
 	set.SetUsage(func() {
 		set.PrintUsage(shell.ConsoleWriter())

--- a/commands/util/dir.go
+++ b/commands/util/dir.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 type DirCommand struct {
@@ -17,7 +16,7 @@ func NewDirCommand() *DirCommand {
 	return &DirCommand{}
 }
 
-func (cmd *DirCommand) AddOptions(set *getopt.Set) {
+func (cmd *DirCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("value")
 	shell.AddCommonCmdOptions(set, shell.CmdDebug, shell.CmdVerbose)
 }

--- a/commands/util/env.go
+++ b/commands/util/env.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 type EnvCommand struct {
@@ -16,7 +15,7 @@ func NewEnvCommand() *EnvCommand {
 	return &EnvCommand{}
 }
 
-func (cmd *EnvCommand) AddOptions(set *getopt.Set) {
+func (cmd *EnvCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("value")
 }
 

--- a/commands/util/log.go
+++ b/commands/util/log.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 type LogCommand struct {
@@ -21,7 +20,7 @@ func NewLogCommand() *LogCommand {
 	return &cmd
 }
 
-func (cmd *LogCommand) AddOptions(set *getopt.Set) {
+func (cmd *LogCommand) AddOptions(set shell.CmdSet) {
 	cmd.cmdTruncate = set.BoolLong("truncate", 0, "Truncate the log file first")
 	cmd.cmdAppend = set.BoolLong("append", 'a', "Append to an existing file")
 	cmd.cmdStop = set.BoolLong("stop", 0, "Stop the current log")

--- a/commands/util/pause.go
+++ b/commands/util/pause.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 var (
@@ -22,7 +21,7 @@ func NewPauseCommand() *PauseCommand {
 	return &PauseCommand{}
 }
 
-func (cmd *PauseCommand) AddOptions(set *getopt.Set) {
+func (cmd *PauseCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("")
 	cmd.messageOption = set.StringLong("message", 'm', DefaultMessage, "Message to display")
 	shell.AddCommonCmdOptions(set, shell.CmdDebug, shell.CmdVerbose)

--- a/commands/util/set.go
+++ b/commands/util/set.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 // Support for unittesting
@@ -27,7 +26,7 @@ func NewSetCommand() *SetCommand {
 	return &SetCommand{}
 }
 
-func (cmd *SetCommand) AddOptions(set *getopt.Set) {
+func (cmd *SetCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("[key[=[value]]...")
 	cmd.listOption = set.BoolLong("list", 'l', "List the globals")
 	cmd.initOnly = set.BoolLong("init", 'i', "Inialize if not set already")

--- a/commands/util/silent.go
+++ b/commands/util/silent.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 type SilentCommand struct {
@@ -17,7 +16,7 @@ func NewSilentCommand() *SilentCommand {
 	return &SilentCommand{}
 }
 
-func (cmd *SilentCommand) AddOptions(set *getopt.Set) {
+func (cmd *SilentCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("value")
 }
 

--- a/commands/util/sleep.go
+++ b/commands/util/sleep.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 type SleepCommand struct {
@@ -18,7 +17,7 @@ func NewSleepCommand() *SleepCommand {
 	return &SleepCommand{}
 }
 
-func (cmd *SleepCommand) AddOptions(set *getopt.Set) {
+func (cmd *SleepCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("[msec]")
 	shell.AddCommonCmdOptions(set, shell.CmdVerbose)
 }

--- a/commands/util/verbose.go
+++ b/commands/util/verbose.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 type VerboseCommand struct {
@@ -17,7 +16,7 @@ func NewVerboseCommand() *VerboseCommand {
 	return &VerboseCommand{}
 }
 
-func (cmd *VerboseCommand) AddOptions(set *getopt.Set) {
+func (cmd *VerboseCommand) AddOptions(set shell.CmdSet) {
 	set.SetParameters("value")
 	shell.AddCommonCmdOptions(set, shell.CmdDebug, shell.CmdVerbose)
 }

--- a/restshell.go
+++ b/restshell.go
@@ -1,93 +1,12 @@
 package main
 
 import (
-	"fmt"
 	"os"
-	"path/filepath"
-	"runtime"
-	"strings"
 
 	"github.com/brada954/restshell/shell"
-	"github.com/pborman/getopt/v2"
 )
 
 func main() {
-	exitCode := 1
-	defer func() {
-		if r := recover(); r == nil {
-			os.Exit(exitCode)
-		} else {
-			fmt.Fprintln(shell.ConsoleWriter(), "Panic:", r)
-			buf := make([]byte, 1<<16)
-			length := runtime.Stack(buf, true)
-			fmt.Fprintln(shell.ConsoleWriter(), string(buf[:length]))
-			os.Exit(100)
-		}
-	}()
-
-	getopt.Parse()
-
-	if shell.IsDisplayHelpEnabled() {
-		shell.DisplayHelp()
-		os.Exit(0)
-	}
-
-	runInitScripts(shell.IsDebugEnabled())
-
-	if len(getopt.Args()) == 0 {
-		cnt, success := shell.CommandProcessor(">> ", os.Stdin, false, false)
-		if !success {
-			fmt.Println("Did not return success")
-		} else {
-			exitCode = shell.LastError
-			fmt.Printf("Processed %d commands\n", cnt)
-		}
-	} else {
-		runCmdLine(getopt.Args())
-		exitCode = shell.LastError
-	}
-}
-
-func runInitScripts(debug bool) {
-	scriptFile := shell.RestShellInitFile
-	runInitScript(scriptFile, debug)
-
-	scriptFile = shell.RestShellUserInitFile
-	runInitScript(scriptFile, debug)
-}
-
-func runInitScript(scriptFile string, debug bool) {
-	if _, err := shell.ValidateScriptExists(scriptFile); err != nil {
-		scriptFile = filepath.Join(shell.GetExeDirectory(), scriptFile)
-	}
-
-	cmdParts := []string{"run -s"}
-	if debug {
-		cmdParts = append(cmdParts, "-d")
-	}
-	cmdParts = append(cmdParts, scriptFile)
-
-	cmdStr := strings.Join(cmdParts, " ")
-	_, _ = shell.CommandProcessor("", strings.NewReader(cmdStr), false, true)
-}
-
-func runCmdLine(args []string) {
-	cmdStr := buildCmdLine(args)
-	_, _ = shell.CommandProcessor("", strings.NewReader(cmdStr), false, true)
-}
-
-func buildCmdLine(args []string) string {
-	for i, v := range args {
-		if i == 0 {
-			args[i] = v
-		} else {
-			args[i] = quoteString(v)
-		}
-	}
-	return strings.Join(args, " ")
-}
-
-func quoteString(str string) string {
-	str = strings.Replace(str, "\\", "\\\\", -1)
-	return "\"" + strings.Replace(str, "\"", "\\\"", -1) + "\""
+	exitCode := shell.RunShell(shell.GetDefaultStartupOptions())
+	os.Exit(exitCode)
 }

--- a/shell/cmd.go
+++ b/shell/cmd.go
@@ -3,14 +3,12 @@ package shell
 import (
 	"reflect"
 	"strings"
-
-	"github.com/pborman/getopt/v2"
 )
 
 // Command - interface for basic command
 type Command interface {
 	Execute([]string) error
-	AddOptions(set *getopt.Set)
+	AddOptions(CmdSet)
 }
 
 // Abortable - interface for commands that support abort
@@ -35,6 +33,7 @@ type CommandWithSubcommands interface {
 	GetSubCommands() []string
 }
 
+// Variables for supported categorizations of commands
 var (
 	CategoryHttp        = "Http"
 	CategorySpecialized = "Specialized"

--- a/shell/getopt.go
+++ b/shell/getopt.go
@@ -1,0 +1,43 @@
+package shell
+
+// getopt.go - Provide an interface to vendored getopt to help reduce dependencies on
+// external getopt package that is in venor
+
+import (
+	"errors"
+	"io"
+
+	"github.com/pborman/getopt/v2"
+)
+
+// CmdSet -- Interface exposing the supported interfaces to commands
+// for setting options
+type CmdSet interface {
+	Reset()
+	Usage()
+	SetProgram(string)
+	SetParameters(string)
+	SetUsage(func())
+	PrintUsage(io.Writer)
+	BoolLong(string, rune, ...string) *bool
+	StringLong(string, rune, string, ...string) *string
+	IntLong(string, rune, int, ...string) *int
+	Int64Long(string, rune, int64, ...string) *int64
+	Args() []string
+	Arg(int) string
+	NArgs() int
+}
+
+func NewCmdSet() CmdSet {
+	return getopt.New()
+}
+
+// CmdParse -- implements the parse/getopt function by hiding an Option type
+// not to be exported in the interface
+func CmdParse(set CmdSet, tokens []string) error {
+	if s, ok := set.(*getopt.Set); ok {
+		return s.Getopt(tokens, nil)
+	} else {
+		return errors.New("Invalid option package used")
+	}
+}

--- a/shell/getopt_test.go
+++ b/shell/getopt_test.go
@@ -1,0 +1,11 @@
+package shell
+
+import "testing"
+
+func TestCreateInterface(t *testing.T) {
+	i := NewCmdOptions()
+
+	i.Reset()
+
+	i.GetOpt(args []string, fn func(Options) bool)
+}

--- a/shell/init.go
+++ b/shell/init.go
@@ -1,9 +1,5 @@
 package shell
 
-var ProgramName = "RestShell"
-var RestShellInitFile = ".rsconfig"
-var RestShellUserInitFile = ".rsconfig.user"
-
 func init() {
 	InitializeShell()
 	EnableGlobalOptions()

--- a/shell/options.go
+++ b/shell/options.go
@@ -5,8 +5,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/pborman/getopt/v2"
 )
 
 //////////////////////////////////////////////////////////////////////
@@ -148,7 +146,7 @@ func (o StandardOptions) Clear(options ...int) StandardOptions {
 }
 
 // InitializeCommonCmdOptions initialize common command options
-func InitializeCommonCmdOptions(set *getopt.Set, options ...int) {
+func InitializeCommonCmdOptions(set CmdSet, options ...int) {
 	ClearCmdOptions()
 	AddCommonCmdOptions(set, options...)
 }
@@ -160,7 +158,7 @@ func ClearCmdOptions() {
 
 // AddCommonCmdOptions -- Add the given command options to the options supported
 // by the current executing command
-func AddCommonCmdOptions(set *getopt.Set, options ...int) {
+func AddCommonCmdOptions(set CmdSet, options ...int) {
 	for _, v := range options {
 		switch v {
 		case CmdHelp:
@@ -436,17 +434,15 @@ func (o *StandardOptions) GetUrlValue(fallback string) (result string) {
 
 	if o.urlOption != nil && *o.urlOption != "" {
 		return *o.urlOption
-	} else {
-		return fallback
 	}
+	return fallback
 }
 
 func (o *StandardOptions) GetHeaderValues(fallback string) string {
 	if o.headersOption != nil {
 		return *o.headersOption
-	} else {
-		return fallback
 	}
+	return fallback
 }
 
 // GetBasicAuthContext -- get the Auth context for the basic auth parameters specified

--- a/shell/rem.go
+++ b/shell/rem.go
@@ -8,8 +8,6 @@ package shell
 
 import (
 	"fmt"
-
-	"github.com/pborman/getopt/v2"
 )
 
 type RemCommand struct {
@@ -19,7 +17,7 @@ func NewRemCommand() *RemCommand {
 	return &RemCommand{}
 }
 
-func (cmd *RemCommand) AddOptions(set *getopt.Set) {
+func (cmd *RemCommand) AddOptions(set CmdSet) {
 }
 
 func (cmd *RemCommand) Execute(args []string) error {

--- a/shell/run.go
+++ b/shell/run.go
@@ -10,8 +10,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/pborman/getopt/v2"
 )
 
 type RunCommand struct {
@@ -34,7 +32,7 @@ func NewRunCommand() *RunCommand {
 	return &cmd
 }
 
-func (cmd *RunCommand) AddOptions(set *getopt.Set) {
+func (cmd *RunCommand) AddOptions(set CmdSet) {
 	set.SetParameters("scripts...")
 	cmd.ifCondition = set.StringLong("cond", 0, "", "run script if specified variable is not empty")
 	cmd.list = set.BoolLong("list", 0, "List the contexts of script file")

--- a/shell/startup.go
+++ b/shell/startup.go
@@ -1,0 +1,152 @@
+package shell
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/pborman/getopt/v2"
+)
+
+// Default settings for startup
+var (
+	DefaultInitFileName = ".rsconfig"
+	DefaultInitFileExt  = ".user"
+	ProgramName         = "RestShell"
+	ProgramArgs         = make([]string, 0, 0)
+)
+
+// StartupOptions -- configuration available to the shell
+type StartupOptions struct {
+	DebugInit         bool
+	InitFile          string
+	InitFileExt       string
+	AbortOnExceptions bool
+}
+
+func (s *StartupOptions) GetInitFileName() string {
+	if len(s.InitFile) > 0 {
+		return s.InitFile
+	} else {
+		return DefaultInitFileName
+	}
+}
+
+func (s *StartupOptions) GetInitFileExt() string {
+	if len(s.InitFileExt) > 0 {
+		return s.InitFileExt
+	} else {
+		return DefaultInitFileExt
+	}
+}
+
+func (s *StartupOptions) IsDebugInitEnabled() bool {
+	return s.DebugInit
+}
+
+func (s *StartupOptions) IsExceptionHandlingEnabled() bool {
+	return s.AbortOnExceptions == false
+}
+
+// GetDefaultStartupOptions return an interface to the options for the shell startup
+func GetDefaultStartupOptions() StartupOptions {
+	return StartupOptions{
+		DebugInit:         false,
+		InitFile:          DefaultInitFileName,
+		InitFileExt:       DefaultInitFileExt,
+		AbortOnExceptions: false,
+	}
+}
+
+// RunShell -- process command line and init scripts
+// and run command processor
+func RunShell(options StartupOptions) (exitCode int) {
+	exitCode = 1
+	if options.IsExceptionHandlingEnabled() {
+		defer func() {
+			if r := recover(); r == nil {
+				return // Pass-thru existing error code
+			} else {
+				fmt.Fprintln(ConsoleWriter(), "Panic:", r)
+				buf := make([]byte, 1<<16)
+				length := runtime.Stack(buf, true)
+				fmt.Fprintln(ConsoleWriter(), string(buf[:length]))
+				exitCode = 100 // Return 100 for exception
+			}
+		}()
+	}
+
+	getopt.Parse()
+
+	if len(os.Args) > 0 {
+		ProgramName = os.Args[0]
+	}
+	ProgramArgs = getopt.Args()
+
+	if IsDisplayHelpEnabled() {
+		DisplayHelp()
+		return 0
+	}
+
+	runInitScripts(options)
+
+	if len(ProgramArgs) == 0 {
+		cnt, success := CommandProcessor(">> ", os.Stdin, false, false)
+		if !success {
+			fmt.Println("Did not return success")
+		} else {
+			fmt.Printf("Processed %d commands\n", cnt)
+			exitCode = LastError
+		}
+	} else {
+		runCmdLine(ProgramArgs)
+		exitCode = LastError
+	}
+	return exitCode
+}
+
+func runInitScripts(options StartupOptions) {
+	scriptFile := options.GetInitFileName()
+	runInitScript(scriptFile, options.IsDebugInitEnabled())
+
+	scriptFile = options.GetInitFileName() + options.GetInitFileExt()
+	runInitScript(scriptFile, options.IsDebugInitEnabled())
+}
+
+func runInitScript(scriptFile string, debug bool) {
+	if _, err := ValidateScriptExists(scriptFile); err != nil {
+		scriptFile = filepath.Join(GetExeDirectory(), scriptFile)
+	}
+
+	cmdParts := []string{"run -s"}
+	if debug {
+		cmdParts = append(cmdParts, "-d")
+	}
+	cmdParts = append(cmdParts, scriptFile)
+
+	cmdStr := strings.Join(cmdParts, " ")
+	_, _ = CommandProcessor("", strings.NewReader(cmdStr), false, true)
+}
+
+func runCmdLine(args []string) {
+	cmdStr := buildCmdLine(args)
+	_, _ = CommandProcessor("", strings.NewReader(cmdStr), false, true)
+}
+
+func buildCmdLine(args []string) string {
+	for i, v := range args {
+		if i == 0 {
+			args[i] = v
+		} else {
+			args[i] = quoteString(v)
+		}
+	}
+	return strings.Join(args, " ")
+}
+
+func quoteString(str string) string {
+	str = strings.Replace(str, "\\", "\\\\", -1)
+	return "\"" + strings.Replace(str, "\"", "\\\"", -1) + "\""
+}

--- a/test/.rsconfig
+++ b/test/.rsconfig
@@ -1,0 +1,3 @@
+REM ## Running the config file for testing RestShell.
+alias MYIPAPI "base http://api.ipify.org"
+alias FAKEAPI "base https://jsonplaceholder.typicode.com\"

--- a/test/Readme.md
+++ b/test/Readme.md
@@ -1,0 +1,47 @@
+# Test directory
+This is the directory containing tests.
+
+Execute the tests.bat file to verify restshell builds and returns success.
+
+```
+C:\> tests.bat
+Building restshell...
+Running general tests...
+REM ## Running the config file for testing RestShell.
+REM ####################################################################
+REM ## General tests
+REM ##
+REM ## Running some basic tests using some well known REST api's
+REM ## All assertions should pass
+REM ##
+REM ## This test requires the .rsconfig file to be loaded due to
+REM ## dependencies on alias command; used to verify alias. An output
+REM ## should have been displayed from the config file above.
+REM ####################################################################
+REM ##
+REM ## Test getting local ip address; assert finds 3 periods in ip address
+REM ##
+get -s /?format=json
+Assertions Passed (3)
+REM ####################################################################
+REM ##
+REM ## Test getting a post from an online mock rest api
+REM ##
+get -s /posts/1
+Assertions Passed (6)
+REM ####################################################################
+REM ##
+REM ## Test an invalid REST api call that will return 404
+REM ##
+get -s /junk/asdf
+GET: HTTP Status: 404 Not Found
+Assertions Passed (2)
+REM ####################################################################
+ALL ASSERTIONS PASSED (11)
+Ran 20 commands in 1177.3ms. Exited with Success
+BUILD SUCCEEDED
+GENERAL TESTS SUCCEEDED
+```
+
+There should be two lines at the end of the run showing the build succeeded and the tests succeeded.
+If the tests succeeded, the %ERRORLEVEL% should be 0 otherwise non-zero.

--- a/test/general.rshell
+++ b/test/general.rshell
@@ -1,0 +1,43 @@
+REM ####################################################################
+REM ## General tests
+REM ##
+REM ## Running some basic tests using some well known REST api's
+REM ## All assertions should pass
+REM ##
+REM ## This test requires the .rsconfig file to be loaded due to
+REM ## dependencies on alias command; used to verify alias. An output
+REM ## should have been displayed from the config file above.
+REM ####################################################################
+assert --clear
+REM ##
+REM ## Test getting local ip address; assert finds 3 periods in ip address
+REM ##
+BASEAPI
+@get -s /?format=json
+assert noerr
+assert hstatus 200
+assert eq --regex "^\\d+(\\.)\\d+(\\.)\\d+(\\.)\\d+$" ip ...
+assert --new --report
+REM ####################################################################
+REM ##
+REM ## Test getting a post from an online mock rest api
+REM ##
+FAKEAPI
+@get -s /posts/1
+assert noerr
+assert hstatus 200
+assert eq userId 1
+assert eq id 1
+assert isstr title
+assert isstr body
+assert --new --report
+REM ####################################################################
+REM ##
+REM ## Test an invalid REST api call that will return 404
+REM ##
+@get -s /junk/asdf
+assert noerr
+assert hstatus 404
+assert --report
+REM ####################################################################
+assert --report-sum

--- a/test/tests.bat
+++ b/test/tests.bat
@@ -1,0 +1,16 @@
+@echo off
+set BUILDRESULT=NO BUILD EXECUTED
+set TESTRESULT=NO TESTS EXECUTED
+cd ..
+echo Building restshell...
+go build
+if /I "%ERRORLEVEL%" NEQ "0" set BUILDRESULT=BUILD FAILED
+if /I "%ERRORLEVEL%" EQU "0" set BUILDRESULT=BUILD SUCCEEDED
+cd test
+echo Running general tests...
+..\restshell run general
+if /I "%ERRORLEVEL%" NEQ "0" set TESTRESULT=GENERAL TESTS FAILED
+if /I "%ERRORLEVEL%" EQU "0" set TESTRESULT=GENERAL TESTS SUCCEEDED
+
+echo %BUILDRESULT%
+echo %TESTRESULT%


### PR DESCRIPTION
BREAKING CHANGE: enable commands to link without having to build with the same vendored getopt library. Abstract the getopt library with a shell interface.