### PR TITLE
Refactor line parsing; no substitution capability

### DIFF
--- a/shell/alias.go
+++ b/shell/alias.go
@@ -34,6 +34,10 @@ func AddAlias(key string, command string, force bool) error {
 
 func RemoveAlias(key string) error {
 	key = strings.TrimSpace(strings.ToUpper(key))
+	if len(key) == 0 {
+		return errors.New("Empty key")
+	}
+
 	if _, ok := aliasStore[key]; !ok {
 		return errors.New("Key not found")
 	}
@@ -44,6 +48,10 @@ func RemoveAlias(key string) error {
 
 func GetAlias(key string) (string, error) {
 	key = strings.TrimSpace(strings.ToUpper(key))
+	if len(key) == 0 {
+		return "", errors.New("Empty key")
+	}
+
 	if value, ok := aliasStore[key]; !ok {
 		return "", errors.New("Key not found")
 	} else {

--- a/shell/line.go
+++ b/shell/line.go
@@ -1,0 +1,97 @@
+package shell
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Line -- a structure for a parsed line
+type Line struct {
+	OriginalLine string
+	CmdLine      string
+	Echo         bool
+	Step         bool
+	NoSubstitute bool
+	IsComment    bool
+	Command      string
+	ArgString    string
+}
+
+// NewCommandLine -- parse command line into a Line
+func NewCommandLine(input string, shellPrefix string) (line *Line) {
+	line = &Line{}
+
+	line.OriginalLine = input
+	line.Echo = false
+	line.Step = false
+	line.NoSubstitute = false
+	line.IsComment = false
+	line.Command = ""
+	line.ArgString = ""
+
+	line.CmdLine = strings.TrimSpace(input)
+	if strings.HasPrefix(line.CmdLine, "#") {
+		line.IsComment = true
+		return
+	}
+
+	// Process prefixes, Triming them one at a time
+	for notDone := true; notDone; {
+		if strings.HasPrefix(line.CmdLine, "@") {
+			line.Echo = true
+			line.CmdLine = strings.TrimSpace(strings.TrimLeft(line.CmdLine, "@"))
+		} else if strings.HasPrefix(line.CmdLine, "!") {
+			line.NoSubstitute = true
+			line.CmdLine = strings.TrimSpace(strings.TrimLeft(line.CmdLine, "!"))
+		} else {
+			notDone = false
+		}
+	}
+
+	if len(shellPrefix) > 0 {
+		line.CmdLine = strings.TrimSpace(shellPrefix + line.CmdLine)
+	}
+
+	line.splitCommandAndArgs()
+
+	// Perform alias substitution
+	if alias, err := GetAlias(line.Command); err == nil {
+		if IsDebugEnabled() {
+			fmt.Fprintf(ConsoleWriter(), "Using alias: %s\n", alias)
+		}
+		if len(line.ArgString) > 0 {
+			line.CmdLine = alias + " " + line.ArgString
+		} else {
+			line.CmdLine = alias
+		}
+	}
+
+	if !line.NoSubstitute {
+		line.CmdLine = PerformVariableSubstitution(line.CmdLine)
+	}
+
+	// Re-calculate new command after aliases and substitutions
+	line.splitCommandAndArgs()
+	return
+}
+
+// GetCmdAndArguments -- get the tokens of the commmand line fully parsed
+func (line *Line) GetCmdAndArguments() []string {
+	args := LineParse(line.ArgString)
+	return append([]string{line.Command}, args...)
+}
+
+// splitCommandAndArgs() -- Regenerate the command and argument
+// strings of the line structure based on current CmdLine
+func (line *Line) splitCommandAndArgs() {
+	line.Command = ""
+	line.ArgString = ""
+
+	args := strings.SplitN(line.CmdLine, " ", 2)
+	if len(args) > 0 {
+		line.Command = strings.ToUpper(args[0])
+	}
+	if len(args) > 1 {
+		line.ArgString = strings.TrimSpace(args[1])
+	}
+}

--- a/shell/lineparse_test.go
+++ b/shell/lineparse_test.go
@@ -20,12 +20,17 @@ func TestParseQuotes(t *testing.T) {
 	testAString(t, "123 \"\\\"abc\\\"\"", []string{"123", "\"abc\""})
 	testAString(t, "123 \" abc \"\"", []string{"123", " abc "})
 	testAString(t, "buy   -v -123", []string{"buy", "-v", "-123"})
+	testAString(t, "", []string{})
+	testAString(t, "test \"\" space", []string{"test", "", "space"})
+	testAString(t, "test \"\"", []string{"test", ""})
+	testAString(t, "test \"", []string{"test", ""})
+	testAString(t, "\"", []string{""})
 }
 
 func testAString(t *testing.T, line string, expected []string) {
 	args := LineParse(line)
 	if len(args) != len(expected) {
-		t.Errorf("Invalid number of tokens %d!=%d", len(args), 2)
+		t.Errorf("Invalid number of tokens %d!=%d for line: %s", len(expected), len(args), line)
 	}
 
 	for i := 0; i < min(len(args), len(expected)); i++ {

--- a/shell/output.go
+++ b/shell/output.go
@@ -79,8 +79,10 @@ func ColumnizeTokens(tokens []string, columns int, width int) []string {
 	return result
 }
 
+// DisplayOption
 type DisplayOption int
 
+// DisplayOption values
 const (
 	Body DisplayOption = iota
 	Headers

--- a/shell/output_test.go
+++ b/shell/output_test.go
@@ -78,7 +78,7 @@ func TestColumnizeFive(t *testing.T) {
 func TestIsStringBinaryWithBinary(t *testing.T) {
 	var text = "{ \013this\013 is a \003test\000 that\013\013\030 needs 10\001 binary ch\013arac\013ters\034}"
 	text = text + "extra c\030racters\030 to get this over 100 be\001ca\001use there"
-	if !isStringBinary(text) {
+	if !IsStringBinary(text) {
 		t.Errorf("Unexpected failure to validate binary string as binary")
 		fmt.Println(text)
 	}
@@ -86,7 +86,7 @@ func TestIsStringBinaryWithBinary(t *testing.T) {
 
 func TestIsStringBinaryWithShortText(t *testing.T) {
 	var text = "{ this is a \003test that needs 10\001 binary characters}"
-	if isStringBinary(text) {
+	if IsStringBinary(text) {
 		t.Errorf("Unexpected failure to validate text string as not binary")
 		fmt.Println(text)
 	}
@@ -95,7 +95,7 @@ func TestIsStringBinaryWithShortText(t *testing.T) {
 func TestIsStringBinaryWithLongText(t *testing.T) {
 	var text = "{ this is a \003test that needs 10\001 binary chara\001cters}"
 	text = text + " some extra characters to get this over 100; 123123"
-	if isStringBinary(text) {
+	if IsStringBinary(text) {
 		t.Errorf("Unexpected failure to validate text string as not binary")
 		fmt.Println(text)
 	}

--- a/shell/subst.go
+++ b/shell/subst.go
@@ -1,0 +1,191 @@
+///////////////////////////////////////////////////////////////////////////
+//  Substitution:
+//  Enable a variable lookup table or dynamic functions to be used
+//  in string substitution.
+//
+//  Dynamic functions
+//  Any function can be registered with the substitution system and used in a
+//  string substitution request when the function name is used. The dynamic
+//  function capabilities include the ability to key any function call
+//  so the same value can be returned in a subsequent call. A different key or
+//  absence of key can result in a different value.
+//
+//  For example, dynamic functions enable a Guid to be created and used in substitution
+//  in a string or HTTP body. Using a key allows the same guid to be substituted
+//  multiple times. Without a key, a function is assumed to return a different
+//  value (but may not if for example a function gettime() called repeatedly
+//  may return the same time due to speed of the CPU)
+//
+//  The substitution system manages a cache of data during the
+//  lifetime of a substitution process.
+//
+//  A package init function can register functions using RegisterSubstitutionHandler. The
+//  function registered identifies a function name and function group. The function
+//  name is used in the substitution process to identify the function to call. The
+//  functions group membership identifies the cached data used to manage key'ed
+//  instance of function data. Multiple functions in the same group can use the
+//  same cache data to ensure consistency for a given key.
+//
+//  It is assumed the user of the function understands the underlying grouping
+//  and key mechanism when using a given function.
+//
+//  A function is defined as: %%funcname([key, [fmt, [option]]])%%
+//  When a function is parsed, the funcname is used to identify a function to
+//  call. The function is given any previous data returned from a function
+//  within a group (a group shares one cache item). Groups allow multiple data elements
+//  to be associated together and accessed through a single key. For example:
+//
+//  A function group may manage the generation and display of a random mailing address.
+//  When any function in the group is called, it would generate a random mailing address
+//  if one was not previously generated. When the function returns the value for substitution
+//  it also returns the raw data used to generate it so the substitution package can
+//  maintain that state with a key. When any other function in the group is called with
+//  the same key, it will get the raw data provided.
+//
+//  There is a newguid() function included in the system to serve as an example.
+//
+package shell
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/satori/go.uuid"
+)
+
+// SubstitutionHandler -- A handler returns a value for substitution given a function name. The handler may
+// be given a fmt string and option string to guide the appropriate formating of data.
+// The raw data is returned enabling re-use of the same data when the same key is used with a function
+// in the same function group).
+type SubstitutionHandler func(cache interface{}, funcName string, fmt string, option string) (value string, data interface{})
+
+// handlerDataCache maintains the raw data returned from functions within a function group.
+// The function group name is used in the lookup
+type handlerDataCache map[string]interface{}
+
+type substHandler struct {
+	group    string
+	function SubstitutionHandler
+}
+
+// Mapping of a function name to handler record identifying the group and handler
+var handlerMap = make(map[string]substHandler)
+
+var regexPattern = `%%([a-zA-Z][a-zA-Z0-9]*)\(([a-zA-Z0-9_]*)(?:,([a-zA-Z0-9\.]+)(?:,\"([a-zA-Z0-9\.]+)\")?)?\)%%`
+
+// RegisterSubstitutionHandler -- Register a substitution function
+func RegisterSubstitutionHandler(groupName string, funcName string, fn SubstitutionHandler) {
+	if _, ok := handlerMap[funcName]; !ok {
+		handlerMap[funcName] = substHandler{groupName, fn}
+	} else {
+		panic("Duplicate substitution registration: " + groupName + "." + funcName)
+	}
+}
+
+// SubstituteString -- perform substitution on a string
+func SubstituteString(input string) string {
+
+	var cache = make(handlerDataCache, 0)
+	var localVars = make(map[string]string, 0)
+
+	fmt.Println("Beginning regex eval (", len(handlerMap), "functions)")
+	pattern, _ := regexp.Compile(regexPattern)
+
+	results := pattern.FindAllStringSubmatch(input, -1)
+	for i, list := range results {
+		fmt.Println("Processing group list: ", i)
+		for _, m := range list {
+			fmt.Println(m)
+		}
+
+		fn := ""
+		key := ""
+		fmt := ""
+		option := ""
+		varName := ""
+
+		if len(list) > 1 {
+			fn = list[1]
+			varName = fn + "("
+		}
+
+		if len(list) > 2 && len(list[2]) > 0 {
+			key = list[2]
+			varName = varName + key
+		}
+
+		if len(list) > 3 && len(list[3]) > 0 {
+			fmt = list[3]
+			varName = varName + "," + fmt
+		}
+
+		if len(list) > 4 && len(list[4]) > 0 {
+			option = list[4]
+			varName = varName + "," + option
+		}
+
+		if len(list) > 1 {
+			varName = varName + ")"
+		}
+
+		if r, ok := handlerMap[fn]; ok {
+			cachekey := r.group + "__" + key
+			data, precached := cache[cachekey]
+			if !precached {
+				data = nil
+			}
+
+			v, c := r.function(data, fn, fmt, option)
+			localVars[varName] = v
+			cache[cachekey] = c
+		}
+	}
+
+	var replaceStrings = make([]string, 0)
+
+	var filter = func(k string, v interface{}) bool {
+		if _, ok := v.(string); !ok {
+			return false
+		}
+		return true
+	}
+
+	var replaceBuilder = func(kStr string, v interface{}) {
+		if rStr, ok := v.(string); ok {
+			replaceStrings = append(replaceStrings, "%%"+kStr+"%%", rStr)
+		}
+	}
+
+	EnumerateGlobals(replaceBuilder, filter)
+
+	for k, v := range localVars {
+		fmt.Println("Adding: ", "%%"+k+"%%", v)
+		replaceStrings = append(replaceStrings, "%%"+k+"%%", v)
+	}
+	r := strings.NewReplacer(replaceStrings...)
+	return r.Replace(input)
+
+	//return input
+}
+
+func init() {
+	// Register substitutes
+	RegisterSubstitutionHandler("newguid", "newguid", NewGuidSubstitute)
+}
+
+// NewGuidSubstitute -- Implementatino of guid substitution
+func NewGuidSubstitute(cache interface{}, subname string, fmt string, option string) (value string, data interface{}) {
+	var guid uuid.UUID
+
+	if cache == nil {
+		guid = uuid.NewV4()
+	} else {
+		guid = cache.(uuid.UUID)
+	}
+
+	switch fmt {
+	default:
+		return guid.String(), guid
+	}
+}

--- a/shell/subst_test.go
+++ b/shell/subst_test.go
@@ -1,0 +1,12 @@
+package shell
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSubstringMatch(t *testing.T) {
+	fmt.Println("Beginning test...")
+	result := SubstituteString("this %%newguid(3)%% is a %%newguid(1,short)%% test %%newguid(3)%%")
+	fmt.Println("Result: ", result)
+}


### PR DESCRIPTION
This pull request takes a refactor of line parsing and a feature to not perform line substitution on commands if the line is prefixed with '!'.

The dynamic substitution initial checkin is included but not used.

Pulling this code to get the refactor.